### PR TITLE
DFG-Viewer: Remove search tab

### DIFF
--- a/extension/site/dfgviewer/browser/dfgviewer_popup_search.mjs
+++ b/extension/site/dfgviewer/browser/dfgviewer_popup_search.mjs
@@ -28,7 +28,7 @@ import { doSearch, registerSearchMenuItemFunction, shouldShowSiteSearch } from "
 
 import { options } from "/base/browser/options/options_loader.mjs";
 
-const dfgviewerStartYear = 1800;
+const dfgviewerStartYear = 1000;
 const dfgviewerEndYear = 2000;
 
 function shouldShowSearchMenuItem(data, filter) {
@@ -36,8 +36,12 @@ function shouldShowSearchMenuItem(data, filter) {
     startYear: dfgviewerStartYear,
     endYear: dfgviewerEndYear,
     dateTestType: "bmd",
-    countryList: [],
+    countryList: [
+      "Germany"
+    ],
   };
+
+  return false;  // Disable all serach functionality for now
 
   if (!shouldShowSiteSearch(data.generalizedData, filter, siteConstraints)) {
     return false;
@@ -63,9 +67,11 @@ async function dfgviewerSearch(generalizedData) {
 //////////////////////////////////////////////////////////////////////////////////////////
 
 function addDfgviewerDefaultSearchMenuItem(menu, data, backFunction, filter) {
-  addMenuItem(menu, "Search DFG Viewer", function (element) {
-    dfgviewerSearch(data.generalizedData);
-  });
+  // addMenuItem(menu, "Search DFG Viewer", function (element) {
+  //   dfgviewerSearch(data.generalizedData);
+  // });
+
+  // TODO: add search menus for each archive instead
 
   return true;
 }

--- a/extension/site/dfgviewer/core/dfgviewer_uri_builder.mjs
+++ b/extension/site/dfgviewer/core/dfgviewer_uri_builder.mjs
@@ -26,7 +26,7 @@ import { StringUtils } from "../../../base/core/string_utils.mjs";
 
 class DfgviewerUriBuilder {
   constructor() {
-    this.uri = "https://www.dfgviewer.org.uk/cgi/search.pl";
+    this.uri = "UNSUPPORTED";
     this.searchTermAdded = false;
   }
 


### PR DESCRIPTION
Removes the search entry accidentally left in.
Fixed the DFG part of https://www.wikitree.com/g2g/1957158/wikitree-sourcer-showing-errors-during-sourcing-citations

I am not sure if this fixes the issue fully, but it should improve the situation, as that search entry should have never been there.