### PR TITLE
fs: fix Create Source detection from Details sidebar

### DIFF
--- a/extension/site/fs/browser/fs_content.js
+++ b/extension/site/fs/browser/fs_content.js
@@ -285,18 +285,14 @@ function shouldUseFetch() {
   // For thise we return true and it will just fail when it doesn't get JSON data back from the fetch.
 
   let useFetch = false;
+  let createSourceDialog = document.querySelector("div[aria-modal='true'][role='dialog'][aria-label='Create Source']");
 
-  if (personDetailsRegex.test(location.href)) {
+  if (createSourceDialog) {
+    useFetch = false;
+  } else if (personDetailsRegex.test(location.href)) {
     useFetch = true;
   } else if (personSourcesRegex.test(location.href)) {
-    let createSourceDialog = document.querySelector(
-      "div[aria-modal='true'][role='dialog'][aria-label='Create Source']"
-    );
-    if (createSourceDialog) {
-      useFetch = false;
-    } else {
-      useFetch = true;
-    }
+    useFetch = true;
   } else if (imageWithSidebarUrlRegEx.test(location.href)) {
     // This is an image with a person details selected
     useFetch = true;

--- a/extension/site/fs/browser/fs_extract_data.js
+++ b/extension/site/fs/browser/fs_extract_data.js
@@ -1124,6 +1124,11 @@ function extractData(document, url) {
   result.url = url;
 
   // first determine what kind of page we are in.
+  let createSourceDialog = document.querySelector("div[aria-modal='true'][role='dialog'][aria-label='Create Source']");
+  if (createSourceDialog) {
+    extractDataForCreateSource(document, result);
+    return result;
+  }
 
   let mainContent = document.querySelector("#main-content-section");
 
@@ -1153,15 +1158,6 @@ function extractData(document, url) {
     mainContent = document.querySelector("#main");
     if (mainContent) {
       // this is a newer format page, only supported for person pages currently
-
-      // check if we are on the sourcers page with the create source dialog up
-      let createSourceDialog = document.querySelector(
-        "div[aria-modal='true'][role='dialog'][aria-label='Create Source']"
-      );
-      if (createSourceDialog) {
-        extractDataForCreateSource(document, result);
-        return result;
-      }
 
       if (personDetailsRegex.test(url)) {
         // it is a person page

--- a/unit_tests/fs/extracted_data/ref/create_source_from_details_sidebar.json
+++ b/unit_tests/fs/extracted_data/ref/create_source_from_details_sidebar.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://www.familysearch.org/tree/person/details/TEST-123",
+  "pageType": "createSource"
+}

--- a/unit_tests/fs/fs_test_content_and_citation.mjs
+++ b/unit_tests/fs/fs_test_content_and_citation.mjs
@@ -752,6 +752,14 @@ const bookRegressionData = [
   },
 ];
 
+const createSourceRegressionData = [
+  {
+    // Synthetic Details page with the Create Source dialog open from the Sources sidebar.
+    caseName: "create_source_from_details_sidebar",
+    url: "https://www.familysearch.org/tree/person/details/TEST-123",
+  },
+];
+
 const optionVariants = [
   {
     variantName: "dataStyle_fsShort_fsCitation",
@@ -815,7 +823,8 @@ function cleanStaleOutputFiles(testManager) {
   //
   let logger = new LocalErrorLogger(testManager.results, "fs_clean");
   let testCaseSets = [regressionData, imageRegressionData, personRegressionData, bookRegressionData];
-  removeStaleOutputFiles("fs", "extracted_data", testCaseSets, logger);
+  let extractedDataTestCaseSets = [...testCaseSets, createSourceRegressionData];
+  removeStaleOutputFiles("fs", "extracted_data", extractedDataTestCaseSets, logger);
   removeStaleOutputFiles("fs", "generalized_data", testCaseSets, logger);
   removeStaleOutputFiles("fs", "citations", testCaseSets, logger);
   removeStaleOutputFiles("fs", "household_tables", testCaseSets, logger);
@@ -843,6 +852,8 @@ async function runTests(testManager) {
   await runExtractDataTests("fs", bookRegressionData, testManager, false, false);
   await runGeneralizeDataTests("fs", generalizeData, bookRegressionData, testManager, false);
   await runBuildCitationTests("fs", functions, bookRegressionData, testManager, optionVariants, false);
+
+  await runExtractDataTests("fs", createSourceRegressionData, testManager, false, false);
 }
 
 export { runTests };

--- a/unit_tests/fs/saved_pages/create_source_from_details_sidebar.html
+++ b/unit_tests/fs/saved_pages/create_source_from_details_sidebar.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>FamilySearch Create Source Dialog Test Fixture</title>
+  </head>
+  <body>
+    <div id="root">
+      <section id="main-content-section" aria-label="Main Content">
+        <section data-testid="person-details-page">
+          <h1>Test Person</h1>
+          <aside data-testid="sources-infosheet">
+            <h2>Sources</h2>
+            <button type="button">Add New Source</button>
+          </aside>
+        </section>
+      </section>
+      <div class="portalsCss_p1pr4d40">
+        <div portal="overlays">
+          <div class="focusColorCss_f1p26s5c moveHandleCss_m1i27s8t" style="position: absolute; transform: none;">
+            <div class="maxSizeCss_mdn2c19" style="opacity: 1; transform: scale(1);">
+              <div aria-modal="true" class="overlayContainerCss_ogpzw30 fixSizeCss_f1aw14ya" role="dialog" aria-label="Create Source">
+                <div class="fixSizeCss_f1aw14ya elevationBaseCss_e1vn31hu" style="border-radius: 12px;">
+                  <div data-size="lg" class="day0_ddwlgof blueTheme_b1udqlrf dialogOverlayCss_d1iafk6n">
+                    <div class="headerWrapperCss_hhdeet0 grayTheme_gucfp3a headerColorCss_h1wtnbvy">
+                      <h2><span class="ellipsisCss_e139x152">Create Source</span></h2>
+                      <button aria-label="Close" data-size="md" type="button">Close</button>
+                    </div>
+                    <div class="contentWrapperCss_c1xavo9g">
+                      <label for="source-date-field">Date</label>
+                      <input aria-label="Event Date" data-testid="source-date-field" id="source-date-field" role="combobox" type="text" value="">
+                      <label for="source-title-field">Title</label>
+                      <input aria-label="Source Title" data-testid="source-title-field" id="source-title-field" name="sourceTitle" type="text" value="">
+                      <label for="source-web-page-field">Web Page (Link to the Record)</label>
+                      <input aria-label="Source Type" data-testid="source-web-page-field" id="source-web-page-field" name="sourceWebPage" type="text" value="">
+                      <label for="source-citation-field">Where The Record Is Found (Citation)</label>
+                      <textarea aria-label="Citation" data-testid="source-citation-field" id="source-citation-field" name="sourceCitation"></textarea>
+                      <label for="source-notes-field">Describe The Record (Notes)</label>
+                      <textarea aria-label="Notes" data-testid="source-notes-field" id="source-notes-field" name="sourceNotes"></textarea>
+                      <label for="source-change-reason-field">Reason to Attach Source</label>
+                      <textarea data-testid="source-change-reason-field" id="source-change-reason-field" name="sourceChangeReason"></textarea>
+                      <button aria-label="Name" data-testid="source-vital-tag-chip-Name" type="button">Name</button>
+                      <button aria-label="Birth" data-testid="source-vital-tag-chip-Birth" type="button">Birth</button>
+                      <input aria-label="Add Source to My Source Box" data-testid="source-add-sourcebox-checkbox" name="sourceAddSourceBox" type="checkbox" checked>
+                      <button data-testid="source-cancel-button" type="reset">Cancel</button>
+                      <button data-testid="source-save-button" type="submit" aria-disabled="true">Save</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR fixes FamilySearch Create Source detection when Add New Source is opened from the Details tab Sources sidebar.

Previously, Details pages were classified by the person details route before the Create Source modal was considered. That meant the content script chose fetch extraction, so DOM-based createSource detection did not run and the popup missed the Set Fields actions.

Changes:

- Add a synthetic regression fixture for a Details page with the Create Source dialog open.
- Treat the Create Source dialog as a modal state before route-based fetch/DOM extraction decisions.
- Classify DOM extraction as createSource before normal page-type detection.

Testing:

- The first commit adds a regression test that fails before the fix.
- The follow-up fix makes the new fs_extract_data / create_source_from_details_sidebar case pass.
- Full suite was run; the expected pre-fix failure is documented on the test-only commit.




