### PR TITLE
Szukajwarchiwach: Fix multi-language support

### DIFF
--- a/extension/base/core/generalize_data_utils.mjs
+++ b/extension/base/core/generalize_data_utils.mjs
@@ -650,6 +650,10 @@ const GD = {
       return ""; // no country recognized
     }
 
+    if (!placeNameMinusCountry) {
+      return "";
+    }
+
     //console.log("inferCountyNameFromPlaceString, placeNameMinusCountry is : " + placeNameMinusCountry);
 
     let countyName = undefined;
@@ -688,6 +692,10 @@ const GD = {
       }
     } else {
       return ""; // no country recognized
+    }
+
+    if (!placeNameMinusCountry) {
+      return "";
     }
 
     //console.log("inferCountyNameFromPlaceString, placeNameMinusCountry is : " + placeNameMinusCountry);
@@ -987,6 +995,10 @@ class PlaceObj {
       return result;
     }
 
+    if (!placeNameMinusCountry) {
+      return result;
+    }
+
     // treat states and counties the same for now
     let placeNameMinusCounty = "";
 
@@ -1048,6 +1060,10 @@ class PlaceObj {
   }
 
   inferTown() {
+    if (!this.placeString) {
+      return "";
+    }
+
     // it can be hard to get the county from the string, the town is harder
     // this is not always going to work but can be useful if you can check it later
     let country = undefined;
@@ -1061,6 +1077,10 @@ class PlaceObj {
       if (country.hasStates) {
         return "";
       }
+    }
+
+    if (!placeNameMinusCountry) {
+      return "";
     }
 
     let countyName = undefined;

--- a/extension/site/szukaj/browser/szukaj_extract_data.js
+++ b/extension/site/szukaj/browser/szukaj_extract_data.js
@@ -27,12 +27,16 @@ SOFTWARE.
 const ATTRIBUTE_TRANSLATIONS = {
   sygnatura: "reference code",
   signatur: "reference code",
+  "архивный шифр": "reference code",
   daty: "dates",
   daten: "dates",
+  "даты": "dates",
   archiwum: "archives",
   archiv: "archives",
+  "архив": "archives",
   zespół: "fonds",
   bestand: "fonds",
+  "коллекция": "fonds",
 };
 
 function extractData(document, url) {
@@ -56,13 +60,13 @@ function extractData(document, url) {
     let title = attribute.querySelector("div.title").textContent.trim().toLowerCase();
     title = ATTRIBUTE_TRANSLATIONS[title] || title;
     let value = attribute.querySelector("div.value").textContent.trim();
-    result.attributes[title] = value.replace("Expand", "").replace("Collapse", "").trim();
+    result.attributes[title] = value.replace("Rozwiń", "").replace("Zwiń", "").replace("Expand", "").replace("Collapse", "").replace("Einklappen", "").replace("Ausklappen", "").replace("Развернуть", "").replace("Свернуть", "").trim();
   }
   for (let attribute of attributes.querySelectorAll('div[class="border-left col-md-3 col-sm-12"]')) {
     let title = attribute.querySelector("div.title").textContent.trim().toLowerCase();
     title = ATTRIBUTE_TRANSLATIONS[title] || title;
     let value = attribute.querySelector("div.value").textContent.trim();
-    result.attributes[title] = value.replace("Expand", "").replace("Collapse", "").trim();
+    result.attributes[title] = value.replace("Rozwiń", "").replace("Zwiń", "").replace("Expand", "").replace("Collapse", "").replace("Einklappen", "").replace("Ausklappen", "").replace("Развернуть", "").replace("Свернуть", "").trim();
   }
 
   let viewer_frame = document.querySelector("iframe.ps-iframe");


### PR DESCRIPTION
Fixed two places were other languages then english was resulting in bloated citations.


Btw. I'm getting the following error for Szukajwarchiwach:

`Running the JavaScript URL violates the following Content Security Policy directive 'script-src 'self' 'wasm-unsafe-eval' 'inline-speculation-rules' http://localhost:* http://127.0.0.1:* chrome-extension://f27b1ae4-e0cf-4c51-ab32-cbd9a61871b4/'. Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present. The action has been blocked.`

(site/szukaj/browser/szukaj_extract_data.js:78)

I have no real clue what causes this or how to fix this, but the extension seems to be working fine still.