### PR TITLE
Fix Archion permalink generation

### DIFF
--- a/extension/base/core/generalize_data_utils.mjs
+++ b/extension/base/core/generalize_data_utils.mjs
@@ -650,6 +650,10 @@ const GD = {
       return ""; // no country recognized
     }
 
+    if (!placeNameMinusCountry) {
+      return "";
+    }
+
     //console.log("inferCountyNameFromPlaceString, placeNameMinusCountry is : " + placeNameMinusCountry);
 
     let countyName = undefined;
@@ -688,6 +692,10 @@ const GD = {
       }
     } else {
       return ""; // no country recognized
+    }
+
+    if (!placeNameMinusCountry) {
+      return "";
     }
 
     //console.log("inferCountyNameFromPlaceString, placeNameMinusCountry is : " + placeNameMinusCountry);
@@ -987,6 +995,10 @@ class PlaceObj {
       return result;
     }
 
+    if (!placeNameMinusCountry) {
+      return result;
+    }
+
     // treat states and counties the same for now
     let placeNameMinusCounty = "";
 
@@ -1048,6 +1060,10 @@ class PlaceObj {
   }
 
   inferTown() {
+    if (!this.placeString) {
+      return "";
+    }
+
     // it can be hard to get the county from the string, the town is harder
     // this is not always going to work but can be useful if you can check it later
     let country = undefined;
@@ -1061,6 +1077,10 @@ class PlaceObj {
       if (country.hasStates) {
         return "";
       }
+    }
+
+    if (!placeNameMinusCountry) {
+      return "";
     }
 
     let countyName = undefined;

--- a/extension/site/archion/browser/archion_extract_data.js
+++ b/extension/site/archion/browser/archion_extract_data.js
@@ -121,7 +121,7 @@ function extractData(document, url) {
       alert("The page number contains invalid characters. Please report this issue.");
       return result;
     }
-    const entry = pageSelect.querySelector("option[value='" + pageSelect.value + "'");
+    const entry = pageSelect.querySelector("option[value='" + pageSelect.value + "']");
     result.pageData = {
       page: parseInt(entry.text),
       pageIdx: Array.from(entry.parentNode.children).indexOf(entry),

--- a/extension/site/archion/browser/archion_extract_data.js
+++ b/extension/site/archion/browser/archion_extract_data.js
@@ -124,6 +124,7 @@ function extractData(document, url) {
     const entry = pageSelect.querySelector("option[value='" + pageSelect.value + "'");
     result.pageData = {
       page: parseInt(entry.text),
+      pageIdx: Array.from(entry.parentNode.children).indexOf(entry),
     };
   }
 

--- a/extension/site/archion/browser/archion_popup.mjs
+++ b/extension/site/archion/browser/archion_popup.mjs
@@ -159,7 +159,7 @@ async function generatePermaLink(ed) {
       return;
     }
 
-    ed.pageData.pageId = await extractPageDataFromDocument(ed.uid, ed.url, ed.pageData.page);
+    ed.pageData.pageId = await extractPageDataFromDocument(ed.uid, ed.url, ed.pageData.pageIdx);
     ed.permalinkBase = await extractPermalinkBaseUrl(ed.url);
 
     if (ed.pageData.pageId == -1 || ed.permalinkBase == null) {


### PR DESCRIPTION
Fix a mistake during permalink generation:

Just because Archion *says* that it is page number XY does *not* mean that the index is really XY, there may be pages skipped in between...

Nasty bug, hope that it now works for all cases (all cases I did test for work)