### PR TITLE
Fix FindAGrave Citations for the non-english versions

### DIFF
--- a/browser_variants/firefox/manifest.json
+++ b/browser_variants/firefox/manifest.json
@@ -138,7 +138,7 @@
     "*://www.arcinsys.niedersachsen.de/*",
     "*://www.digitale-sammlungen.de/*",
     "*://www.doew.at/*",
-    "*://www.findagrave.com/*",
+    "*://*.findagrave.com/*",
     "*://www.freecen.org.uk/*",
     "*://www.freereg.org.uk/*",
     "*://www.gda.bayern.de/*",

--- a/browser_variants/safari/ios/manifest.json
+++ b/browser_variants/safari/ios/manifest.json
@@ -139,7 +139,7 @@
     "*://www.arcinsys.niedersachsen.de/*",
     "*://www.digitale-sammlungen.de/*",
     "*://www.doew.at/*",
-    "*://www.findagrave.com/*",
+    "*://*.findagrave.com/*",
     "*://www.freecen.org.uk/*",
     "*://www.freereg.org.uk/*",
     "*://www.gda.bayern.de/*",

--- a/browser_variants/safari/macos/manifest.json
+++ b/browser_variants/safari/macos/manifest.json
@@ -136,7 +136,7 @@
     "*://www.arcinsys.niedersachsen.de/*",
     "*://www.digitale-sammlungen.de/*",
     "*://www.doew.at/*",
-    "*://www.findagrave.com/*",
+    "*://*.findagrave.com/*",
     "*://www.freecen.org.uk/*",
     "*://www.freereg.org.uk/*",
     "*://www.gda.bayern.de/*",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -136,7 +136,7 @@
     "*://www.arcinsys.niedersachsen.de/*",
     "*://www.digitale-sammlungen.de/*",
     "*://www.doew.at/*",
-    "*://www.findagrave.com/*",
+    "*://*.findagrave.com/*",
     "*://www.freecen.org.uk/*",
     "*://www.freereg.org.uk/*",
     "*://www.gda.bayern.de/*",

--- a/extension/site/ancestry/core/ancestry_build_citation.mjs
+++ b/extension/site/ancestry/core/ancestry_build_citation.mjs
@@ -194,7 +194,7 @@ function getSharingPageRefTitle(titleCollection) {
 function modifyValueForUrl(builder, value) {
   let target = builder.getOptions().citation_general_target;
 
-  if (value.startsWith("https://www.findagrave.com/memorial")) {
+  if (value.matches("findagrave.com/memorial")) {
     if (target == "wikitree") {
       let memorialId = value.replace(/^https\:\/\/www\.findagrave\.com\/memorial\/(\d+)\/.*$/, "$1");
       if (memorialId && memorialId != value) {

--- a/extension/site/fg/core/fg_site_data.mjs
+++ b/extension/site/fg/core/fg_site_data.mjs
@@ -26,7 +26,7 @@ import { registerSite } from "../../../base/core/site_registry.mjs";
 
 const siteData = {
   siteName: "fg",
-  matches: ["*://www.findagrave.com/*"],
+  matches: ["*://*.findagrave.com/*"],
   additionalContentJsFiles: ["base/browser/content/wt_icons_common", "fg_content_wt_icons"],
   runAt: "document_end",
   repositoryName: "Find a Grave",


### PR DESCRIPTION
For example:  https://de.findagrave.com/memorial/260596993/franciszek-kruk

Now produces:
* '''Memorial''': Find a Grave (no image)<br/>{{FindAGrave|260596993}} (accessed 30 August 2026)<br/>Memorial page for Franciszek Kruk (1 Apr 1899-2 Jan 1945), citing Konzentrationslager Hersbruck, Hersbruck, Nürnberger Land, Bayern, Deutschland.

Note that the url starts with "de." and not "www.".
Sourcer was previously only accepting the "www." variant, now also accepting "*.findagrave.com"