### PR TITLE
noda: Pad day and month to 2 characters

### DIFF
--- a/extension/site/noda/core/noda_uri_builder.mjs
+++ b/extension/site/noda/core/noda_uri_builder.mjs
@@ -100,7 +100,7 @@ class NodaUriBuilder {
       this.addSearchParameter("birth_year_to", year);
     }
     if (month && day) {
-      this.addSearchParameter("birth_date", month + "-" + day);
+      this.addSearchParameter("birth_date", String(month).padStart(2, "0") + "-" + String(day).padStart(2, "0"));
     }
   }
 
@@ -132,7 +132,7 @@ class NodaUriBuilder {
       this.addSearchParameter("event_year_to", year);
     }
     if (month && day) {
-      this.addSearchParameter("event_date", month + "-" + day);
+      this.addSearchParameter("event_date", String(month).padStart(2, "0") + "-" + String(day).padStart(2, "0"));
     }
   }
 

--- a/unit_tests/noda/search_url/ref/ancestry_norway_baptism_1889_knud.json
+++ b/unit_tests/noda/search_url/ref/ancestry_norway_baptism_1889_knud.json
@@ -1,17 +1,17 @@
 {
   "std": {
-    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&birth_year_from=1889&birth_year_to=1889&birth_date=1-31"
+    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&birth_year_from=1889&birth_year_to=1889&birth_date=01-31"
   },
   "sameCollection": {
-    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&lt[]=dp&birth_year_from=1889&birth_year_to=1889&birth_date=1-31&m[]=1235&event_year_from=1889&event_year_to=1889&event_date=2-24&related_first_name=Lars&related_last_name=Knudsen&related_roles[]=far"
+    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&lt[]=dp&birth_year_from=1889&birth_year_to=1889&birth_date=01-31&m[]=1235&event_year_from=1889&event_year_to=1889&event_date=02-24&related_first_name=Lars&related_last_name=Knudsen&related_roles[]=far"
   },
   "specifiedParametersCategory": {
-    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&sc[]=kb&birth_year_from=1889&birth_year_to=1889&birth_date=1-31"
+    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&sc[]=kb&birth_year_from=1889&birth_year_to=1889&birth_date=01-31"
   },
   "specifiedParametersRegion": {
-    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&birth_year_from=1889&birth_year_to=1889&birth_date=1-31&r[]=3"
+    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&birth_year_from=1889&birth_year_to=1889&birth_date=01-31&r[]=3"
   },
   "specifiedParametersPlace": {
-    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&birth_year_from=1889&birth_year_to=1889&birth_date=1-31&m[]=0124"
+    "url": "https://www.digitalarkivet.no/en/search/persons/advanced?firstname=Knud&genders%5B%5D=m&birth_year_from=1889&birth_year_to=1889&birth_date=01-31&m[]=0124"
   }
 }


### PR DESCRIPTION
On digitalarkivet, if you specify dates without the leading 0, they are silently ignored. 

This PR fixes the bug by padding all day and month values to 2 chars.